### PR TITLE
Пагинация для кошельков и транзакций

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+.claude

--- a/FinanceTrack.Client.Browser/package-lock.json
+++ b/FinanceTrack.Client.Browser/package-lock.json
@@ -16,6 +16,7 @@
         "@react-keycloak/web": "^3.4.0",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-devtools": "^5.91.3",
+        "@tanstack/react-virtual": "^3.13.24",
         "@toolpad/core": "^0.12.1",
         "jotai": "^2.12.1",
         "keycloak-js": "^26.2.1",
@@ -3148,6 +3149,33 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.20",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@toolpad/core": {

--- a/FinanceTrack.Client.Browser/package.json
+++ b/FinanceTrack.Client.Browser/package.json
@@ -34,6 +34,7 @@
     "@react-keycloak/web": "^3.4.0",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
+    "@tanstack/react-virtual": "^3.13.24",
     "@toolpad/core": "^0.12.1",
     "jotai": "^2.12.1",
     "keycloak-js": "^26.2.1",

--- a/FinanceTrack.Client.Browser/src/pages/WalletPage/WalletPage.tsx
+++ b/FinanceTrack.Client.Browser/src/pages/WalletPage/WalletPage.tsx
@@ -1,12 +1,14 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   Box,
   Button,
   Card,
   CardContent,
   Chip,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -174,24 +176,39 @@ const formatDateShort = (dateStr: string): string => {
   });
 };
 
+const fetchTransactionDateRange = async (
+  walletId: string,
+): Promise<TransactionDateRange | null> => {
+  const res = await fetch(
+    `/api/finance/Wallets/${walletId}/Transactions/Meta/DateRange`,
+    { credentials: 'include' },
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(getErrorMessage('загрузки диапазона дат', res.status));
+  return await res.json();
+};
+
 const fetchTransactions = async (
   walletId: string,
-  from?: string,
-  to?: string
-): Promise<Transaction[]> => {
+  from: string,
+  to: string,
+  pageSize: number,
+  afterCursor: string | null,
+): Promise<TransactionsPage> => {
   const params = new URLSearchParams();
-  if (from) params.append('from', from);
-  if (to) params.append('to', to);
-  
-  const url = `/api/finance/Wallets/${walletId}/Transactions${params.toString() ? `?${params.toString()}` : ''}`;
-  const res = await fetch(url, {
-    credentials: 'include',
-  });
+  params.append('from', from);
+  params.append('to', to);
+  params.append('pageSize', String(pageSize));
+  if (afterCursor) params.append('afterCursor', afterCursor);
+
+  const res = await fetch(
+    `/api/finance/Wallets/${walletId}/Transactions?${params.toString()}`,
+    { credentials: 'include' },
+  );
   if (!res.ok) {
     throw new Error(getErrorMessage('загрузки транзакций', res.status));
   }
-  const data: TransactionsResponse = await res.json();
-  return data.transactions;
+  return await res.json();
 };
 
 const fetchCategories = async (type: 'Income' | 'Expense'): Promise<Category[]> => {
@@ -402,9 +419,13 @@ type Transaction = {
   description: string | null;
 };
 
-type TransactionsResponse = {
+type TransactionsPage = {
   transactions: Transaction[];
+  nextCursor: string | null;
+  hasMore: boolean;
 };
+
+type TransactionDateRange = { minDate: string; maxDate: string };
 
 type CreateIncomePayload = {
   walletId: string;
@@ -554,6 +575,7 @@ function WalletPage() {
   const [filterEndYear, setFilterEndYear] = useState<number>(now.getFullYear());
   const [filterEndMonth, setFilterEndMonth] = useState<number>(now.getMonth() + 1);
   const [filtersInitialized, setFiltersInitialized] = useState(false);
+  const [pageSize, setPageSize] = useState<20 | 30 | 40>(20);
   const [transactionForm, setTransactionForm] = useState<TransactionFormState>({
     name: '',
     amount: '',
@@ -594,28 +616,13 @@ function WalletPage() {
     retry: false,
   });
 
-  // Загружаем все транзакции для определения диапазона дат
-  const { data: allTransactions = [] } = useQuery({
-    queryKey: ['transactions', walletId, 'all'],
-    queryFn: () => fetchTransactions(walletId!),
+  // Диапазон дат транзакций (для инициализации фильтров)
+  const { data: dateRange } = useQuery({
+    queryKey: ['transactions', walletId, 'meta', 'dateRange'],
+    queryFn: () => fetchTransactionDateRange(walletId!),
     enabled: !!walletId && !wallet?.isArchived,
     retry: false,
   });
-
-  // Определяем самую позднюю и самую раннюю даты транзакций
-  const latestTransactionDate = useMemo(() => {
-    if (allTransactions.length === 0) return null;
-    const dates = allTransactions.map((t) => new Date(t.operationDate));
-    const latest = new Date(Math.max(...dates.map((d) => d.getTime())));
-    return latest;
-  }, [allTransactions]);
-
-  const earliestTransactionDate = useMemo(() => {
-    if (allTransactions.length === 0) return null;
-    const dates = allTransactions.map((t) => new Date(t.operationDate));
-    const earliest = new Date(Math.min(...dates.map((d) => d.getTime())));
-    return earliest;
-  }, [allTransactions]);
 
   // Определяем диапазон годов для фильтров
   const availableYears = useMemo(() => {
@@ -623,25 +630,20 @@ function WalletPage() {
     let minYear = currentYear - 10;
     let maxYear = currentYear;
 
-    if (earliestTransactionDate) {
-      const earliestYear = earliestTransactionDate.getFullYear();
-      minYear = Math.min(minYear, earliestYear);
-    }
-    if (latestTransactionDate) {
-      const latestYear = latestTransactionDate.getFullYear();
-      maxYear = Math.max(maxYear, latestYear);
+    if (dateRange) {
+      minYear = Math.min(minYear, new Date(dateRange.minDate).getFullYear());
+      maxYear = Math.max(maxYear, new Date(dateRange.maxDate).getFullYear());
     }
 
-    // Добавляем небольшой запас
-    minYear = Math.max(2000, minYear - 1); // Не раньше 2000 года
-    maxYear = Math.min(2100, maxYear + 1); // Не позже 2100 года
+    minYear = Math.max(2000, minYear - 1);
+    maxYear = Math.min(2100, maxYear + 1);
 
     const years: number[] = [];
     for (let year = maxYear; year >= minYear; year--) {
       years.push(year);
     }
     return years;
-  }, [earliestTransactionDate, latestTransactionDate, now]);
+  }, [dateRange]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Сбрасываем фильтры при смене кошелька
   useEffect(() => {
@@ -653,33 +655,70 @@ function WalletPage() {
     setFilterEndMonth(currentDate.getMonth() + 1);
   }, [walletId]);
 
-  // Устанавливаем фильтры на основе самой поздней транзакции
+  // Устанавливаем фильтры на основе диапазона дат с сервера
   useEffect(() => {
     if (!filtersInitialized && walletId) {
-      if (latestTransactionDate) {
-        // Если есть транзакции, устанавливаем фильтры на основе самой поздней
-        const year = latestTransactionDate.getFullYear();
-        const month = latestTransactionDate.getMonth() + 1;
-        setFilterEndYear(year);
-        setFilterEndMonth(month);
-        setFilterStartYear(year);
-        setFilterStartMonth(month);
+      if (dateRange) {
+        const minDate = new Date(dateRange.minDate);
+        const maxDate = new Date(dateRange.maxDate);
+        setFilterStartYear(minDate.getFullYear());
+        setFilterStartMonth(minDate.getMonth() + 1);
+        setFilterEndYear(maxDate.getFullYear());
+        setFilterEndMonth(maxDate.getMonth() + 1);
       }
-      // Если транзакций нет, фильтры остаются на текущем месяце (уже установлены по умолчанию)
       setFiltersInitialized(true);
     }
-  }, [latestTransactionDate, filtersInitialized, walletId]);
+  }, [dateRange, filtersInitialized, walletId]);
 
   // Формируем даты для фильтрации
   const filterFrom = `${filterStartYear}-${String(filterStartMonth).padStart(2, '0')}-01`;
   const filterTo = `${filterEndYear}-${String(filterEndMonth).padStart(2, '0')}-${new Date(filterEndYear, filterEndMonth, 0).getDate()}`;
 
-  const { data: transactions = [] } = useQuery({
-    queryKey: ['transactions', walletId, filterFrom, filterTo],
-    queryFn: () => fetchTransactions(walletId!, filterFrom, filterTo),
+  const {
+    data: transactionsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ['transactions', walletId, filterFrom, filterTo, pageSize],
+    queryFn: ({ pageParam }) =>
+      fetchTransactions(walletId!, filterFrom, filterTo, pageSize, pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.nextCursor : undefined),
     enabled: !!walletId && !wallet?.isArchived && filtersInitialized,
     retry: false,
   });
+
+  const allTransactions = useMemo(() => {
+    const seen = new Set<string>();
+    return (transactionsData?.pages ?? [])
+      .flatMap((p) => p.transactions)
+      .filter((t) => {
+        if (seen.has(t.id)) return false;
+        seen.add(t.id);
+        return true;
+      });
+  }, [transactionsData]);
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: allTransactions.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => 53,
+    overscan: 10,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  // Шаг 11 — InfiniteScroll: загружаем следующую страницу при достижении конца
+  useEffect(() => {
+    const lastItem = virtualItems[virtualItems.length - 1];
+    if (!lastItem) return;
+    if (lastItem.index >= allTransactions.length - 1 && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [virtualItems, hasNextPage, isFetchingNextPage, fetchNextPage, allTransactions.length]);
 
   const { data: incomeCategories = [] } = useQuery({
     queryKey: ['categories', 'Income'],
@@ -749,10 +788,9 @@ function WalletPage() {
       transactionType === 'Income' ? createIncome(payload as CreateIncomePayload) : createExpense(payload as CreateExpensePayload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['transactions', walletId] });
+      queryClient.invalidateQueries({ queryKey: ['transactions', walletId, 'meta', 'dateRange'] });
       queryClient.invalidateQueries({ queryKey: ['wallet', walletId] });
       queryClient.invalidateQueries({ queryKey: ['wallets'] });
-      // Сбрасываем инициализацию фильтров, чтобы они обновились с учетом новой транзакции
-      setFiltersInitialized(false);
       setTransactionDialogOpen(false);
       setTransactionForm({
         name: '',
@@ -775,6 +813,7 @@ function WalletPage() {
       updateTransaction(transactionId, payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['transactions', walletId] });
+      queryClient.invalidateQueries({ queryKey: ['transactions', walletId, 'meta', 'dateRange'] });
       queryClient.invalidateQueries({ queryKey: ['wallet', walletId] });
       queryClient.invalidateQueries({ queryKey: ['wallets'] });
       setTransactionDialogOpen(false);
@@ -798,6 +837,7 @@ function WalletPage() {
     mutationFn: deleteTransaction,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['transactions', walletId] });
+      queryClient.invalidateQueries({ queryKey: ['transactions', walletId, 'meta', 'dateRange'] });
       queryClient.invalidateQueries({ queryKey: ['wallet', walletId] });
       queryClient.invalidateQueries({ queryKey: ['wallets'] });
       setDeleteConfirmOpen(false);
@@ -1124,11 +1164,6 @@ function WalletPage() {
 
     createTransferMutation.mutate(payload);
   };
-
-  // Сортируем все транзакции по дате (новые сверху)
-  const sortedTransactions = [...transactions].sort(
-    (a, b) => new Date(b.operationDate).getTime() - new Date(a.operationDate).getTime()
-  );
 
   const availableWallets = allWallets.filter((w) => !w.isArchived);
   const fromWallets = availableWallets.filter((w) => w.id !== transferForm.toWalletId);
@@ -1669,104 +1704,154 @@ function WalletPage() {
                     ))}
                   </Select>
                 </FormControl>
+
+                <Typography variant="body2" color="text.secondary" sx={{ ml: 2 }}>
+                  На странице:
+                </Typography>
+                <FormControl size="small" sx={{ minWidth: 80 }}>
+                  <Select
+                    value={pageSize}
+                    onChange={(e) => setPageSize(e.target.value as 20 | 30 | 40)}
+                  >
+                    <MenuItem value={20}>20</MenuItem>
+                    <MenuItem value={30}>30</MenuItem>
+                    <MenuItem value={40}>40</MenuItem>
+                  </Select>
+                </FormControl>
               </Box>
             </Box>
 
-            {sortedTransactions.length === 0 ? (
+            {allTransactions.length === 0 && filtersInitialized ? (
               <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 3 }}>
                 Нет транзакций. Добавьте доход, расход или перевод.
               </Typography>
             ) : (
-              <TableContainer component={Paper} variant="outlined">
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Дата</TableCell>
-                      <TableCell>Название</TableCell>
-                      <TableCell align="right">Сумма</TableCell>
-                      <TableCell align="right">Действия</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {sortedTransactions.map((transaction) => {
-                      const isTransfer = transaction.type === 'TransferIn' || transaction.type === 'TransferOut';
-                      const isIncome = transaction.type === 'Income';
-                      const isExpense = transaction.type === 'Expense';
-                      
-                      let displayName = transaction.name;
-                      if (isTransfer) {
-                        displayName = transaction.type === 'TransferOut' 
-                          ? `↗ ${transaction.name}` 
-                          : `↙ ${transaction.name}`;
-                      }
+              <>
+                <TableContainer
+                  ref={scrollContainerRef}
+                  component={Paper}
+                  variant="outlined"
+                  sx={{ height: 480, overflow: 'auto' }}
+                >
+                  <Table size="small" sx={{ tableLayout: 'fixed' }}>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell sx={{ width: 100 }}>Дата</TableCell>
+                        <TableCell>Название</TableCell>
+                        <TableCell align="right" sx={{ width: 140 }}>Сумма</TableCell>
+                        <TableCell align="right" sx={{ width: 90 }}>Действия</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {virtualItems.length > 0 && virtualItems[0].start > 0 && (
+                        <TableRow sx={{ height: virtualItems[0].start }}>
+                          <TableCell colSpan={4} sx={{ p: 0, border: 0 }} />
+                        </TableRow>
+                      )}
 
-                      return (
-                        <TableRow key={transaction.id}>
-                          <TableCell>{formatDateShort(transaction.operationDate)}</TableCell>
-                          <TableCell>
-                            <Box>
-                              <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 0.5 }}>
-                                {formatDisplayName(displayName)}
-                                {isTransfer && (
-                                  <Chip
-                                    label={transaction.type === 'TransferOut' ? 'Исходящий' : 'Входящий'}
-                                    size="small"
-                                    variant="outlined"
-                                  />
+                      {virtualItems.map((virtualRow) => {
+                        const transaction = allTransactions[virtualRow.index];
+                        const isTransfer = transaction.type === 'TransferIn' || transaction.type === 'TransferOut';
+                        const isIncome = transaction.type === 'Income';
+                        const isExpense = transaction.type === 'Expense';
+
+                        let displayName = transaction.name;
+                        if (isTransfer) {
+                          displayName = transaction.type === 'TransferOut'
+                            ? `↗ ${transaction.name}`
+                            : `↙ ${transaction.name}`;
+                        }
+
+                        return (
+                          <TableRow
+                            key={transaction.id}
+                            ref={virtualizer.measureElement}
+                            data-index={virtualRow.index}
+                          >
+                            <TableCell>{formatDateShort(transaction.operationDate)}</TableCell>
+                            <TableCell>
+                              <Box>
+                                <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 0.5 }}>
+                                  {formatDisplayName(displayName)}
+                                  {isTransfer && (
+                                    <Chip
+                                      label={transaction.type === 'TransferOut' ? 'Исходящий' : 'Входящий'}
+                                      size="small"
+                                      variant="outlined"
+                                    />
+                                  )}
+                                </Box>
+                                {isTransfer && transaction.relatedWalletName && (
+                                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                                    {transaction.type === 'TransferOut'
+                                      ? `→ ${transaction.relatedWalletName}`
+                                      : `← ${transaction.relatedWalletName}`}
+                                  </Typography>
                                 )}
                               </Box>
-                              {isTransfer && transaction.relatedWalletName && (
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                                  {transaction.type === 'TransferOut' 
-                                    ? `→ ${transaction.relatedWalletName}`
-                                    : `← ${transaction.relatedWalletName}`}
-                                </Typography>
-                              )}
-                            </Box>
-                          </TableCell>
-                          <TableCell align="right">
-                            <Typography
-                              color={
-                                isIncome
-                                  ? 'success.main'
-                                  : isExpense
-                                    ? 'error.main'
-                                    : transaction.type === 'TransferOut'
-                                      ? 'warning.main'
-                                      : 'info.main'
-                              }
-                              fontWeight="bold"
-                            >
-                              {isIncome ? '+' : isExpense ? '-' : transaction.type === 'TransferOut' ? '↗' : '↙'}
-                              {formatMoney(transaction.amount)}
-                            </Typography>
-                          </TableCell>
-                          <TableCell align="right">
-                            <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'flex-end' }}>
-                              {!isTransfer && (
+                            </TableCell>
+                            <TableCell align="right">
+                              <Typography
+                                color={
+                                  isIncome
+                                    ? 'success.main'
+                                    : isExpense
+                                      ? 'error.main'
+                                      : transaction.type === 'TransferOut'
+                                        ? 'warning.main'
+                                        : 'info.main'
+                                }
+                                fontWeight="bold"
+                              >
+                                {isIncome ? '+' : isExpense ? '-' : transaction.type === 'TransferOut' ? '↗' : '↙'}
+                                {formatMoney(transaction.amount)}
+                              </Typography>
+                            </TableCell>
+                            <TableCell align="right">
+                              <Box sx={{ display: 'flex', gap: 0.5, justifyContent: 'flex-end' }}>
+                                {!isTransfer && (
+                                  <IconButton
+                                    size="small"
+                                    color="primary"
+                                    onClick={() => handleEditTransaction(transaction)}
+                                  >
+                                    <EditIcon fontSize="small" />
+                                  </IconButton>
+                                )}
                                 <IconButton
                                   size="small"
-                                  color="primary"
-                                  onClick={() => handleEditTransaction(transaction)}
+                                  color="error"
+                                  onClick={() => handleDeleteClick(transaction.id)}
                                 >
-                                  <EditIcon fontSize="small" />
+                                  <DeleteIcon fontSize="small" />
                                 </IconButton>
-                              )}
-                              <IconButton
-                                size="small"
-                                color="error"
-                                onClick={() => handleDeleteClick(transaction.id)}
-                              >
-                                <DeleteIcon fontSize="small" />
-                              </IconButton>
-                            </Box>
-                          </TableCell>
+                              </Box>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+
+                      {virtualItems.length > 0 && (
+                        <TableRow
+                          sx={{
+                            height:
+                              virtualizer.getTotalSize() -
+                              virtualItems[virtualItems.length - 1].end,
+                          }}
+                        >
+                          <TableCell colSpan={4} sx={{ p: 0, border: 0 }} />
                         </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-              </TableContainer>
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+
+                {isFetchingNextPage && (
+                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+                    <CircularProgress size={20} />
+                  </Box>
+                )}
+              </>
             )}
           </CardContent>
         </Card>

--- a/FinanceTrack.Client.Browser/src/pages/WalletPage/WalletPage.tsx
+++ b/FinanceTrack.Client.Browser/src/pages/WalletPage/WalletPage.tsx
@@ -737,7 +737,7 @@ function WalletPage() {
   // Используем те же категории для рекуррентных транзакций
 
   const { data: allWallets = [] } = useQuery({
-    queryKey: ['wallets'],
+    queryKey: ['wallets-for-transfer'],
     queryFn: fetchAllWallets,
     enabled: transferDialogOpen,
     retry: false,

--- a/FinanceTrack.Client.Browser/src/pages/WalletPage/WalletPage.tsx
+++ b/FinanceTrack.Client.Browser/src/pages/WalletPage/WalletPage.tsx
@@ -680,7 +680,7 @@ function WalletPage() {
     hasNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery({
-    queryKey: ['transactions', walletId, filterFrom, filterTo, pageSize],
+    queryKey: ['transactions', walletId, filterFrom, filterTo],
     queryFn: ({ pageParam }) =>
       fetchTransactions(walletId!, filterFrom, filterTo, pageSize, pageParam),
     initialPageParam: null as string | null,

--- a/FinanceTrack.Client.Browser/src/pages/WalletsArchivePage/WalletsArchivePage.tsx
+++ b/FinanceTrack.Client.Browser/src/pages/WalletsArchivePage/WalletsArchivePage.tsx
@@ -1,15 +1,18 @@
+import { useEffect, useRef, useMemo } from 'react';
 import { useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Box,
   Button,
   Card,
   CardContent,
   Chip,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
+  LinearProgress,
   Typography,
 } from '@mui/material';
 import Grid2 from '@mui/material/Grid2';
@@ -31,38 +34,43 @@ type Wallet = {
   isArchived: boolean;
 };
 
-type WalletsResponse = {
+type WalletsPage = {
   wallets: Wallet[];
+  nextCursor: string | null;
+  hasMore: boolean;
 };
 
 const getErrorMessage = (operation: string, status: number): string => {
   return `Ошибка ${operation}: ${status}`;
 };
 
-const fetchArchivedWallets = async (): Promise<Wallet[]> => {
-  const res = await fetch('/api/finance/Wallets/archive', {
+const PAGE_SIZE = 30;
+
+const fetchArchivedWallets = async ({
+  pageParam,
+}: {
+  pageParam: string | null;
+}): Promise<WalletsPage> => {
+  const params = new URLSearchParams();
+  params.append('pageSize', String(PAGE_SIZE));
+  if (pageParam) params.append('afterCursor', pageParam);
+
+  const res = await fetch(`/api/finance/Wallets/archive?${params.toString()}`, {
     credentials: 'include',
   });
-  if (!res.ok) {
-    throw new Error(getErrorMessage('загрузки архивных кошельков', res.status));
-  }
-  const data: WalletsResponse = await res.json();
-  return data.wallets;
+  if (!res.ok) throw new Error(getErrorMessage('загрузки архивных кошельков', res.status));
+  return await res.json();
 };
 
 const unarchiveWallet = async (walletId: string): Promise<void> => {
   const res = await fetch(`/api/finance/Wallets/${walletId}/unarchive`, {
     credentials: 'include',
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: '{}', // FastEndpoints default behaviour requirement
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
   });
 
-  if (!res.ok) {
-    throw new Error(getErrorMessage('разархивации кошелька', res.status));
-  }
+  if (!res.ok) throw new Error(getErrorMessage('разархивации кошелька', res.status));
 };
 
 const formatMoney = (value: number): string => {
@@ -86,15 +94,53 @@ const formatDate = (dateStr: string | null): string => {
 
 function WalletsArchivePage() {
   const queryClient = useQueryClient();
+  const sentinelRef = useRef<HTMLDivElement>(null);
   const [unarchiveConfirmOpen, setUnarchiveConfirmOpen] = useState(false);
   const [walletToUnarchive, setWalletToUnarchive] = useState<Wallet | null>(null);
   const [errorDialog, setErrorDialog] = useState({ open: false, message: '' });
 
-  const { data: wallets, isLoading, isPending, error } = useQuery({
+  const {
+    data: walletsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    error,
+  } = useInfiniteQuery({
     queryKey: ['wallets-archive'],
     queryFn: fetchArchivedWallets,
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.nextCursor : undefined),
     retry: false,
   });
+
+  const wallets = useMemo(() => {
+    const seen = new Set<string>();
+    return (walletsData?.pages ?? [])
+      .flatMap((p) => p.wallets)
+      .filter((w) => {
+        if (seen.has(w.id)) return false;
+        seen.add(w.id);
+        return true;
+      });
+  }, [walletsData]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const unarchiveWalletMutation = useMutation({
     mutationFn: (walletId: string) => unarchiveWallet(walletId),
@@ -121,7 +167,7 @@ function WalletsArchivePage() {
     }
   };
 
-  if (isLoading || isPending) {
+  if (isLoading) {
     return <Loading />;
   }
 
@@ -142,7 +188,7 @@ function WalletsArchivePage() {
         <Typography variant="h4">Архивные кошельки</Typography>
       </Box>
 
-      {(!wallets || wallets.length === 0) && (
+      {wallets.length === 0 && (
         <Box sx={{ textAlign: 'center', py: 4 }}>
           <Typography variant="h5" gutterBottom>
             Нет архивных кошельков
@@ -153,7 +199,7 @@ function WalletsArchivePage() {
         </Box>
       )}
 
-      {wallets && wallets.length > 0 && (
+      {wallets.length > 0 && (
         <Grid2 container spacing={2}>
           {wallets.map((wallet) => (
             <Grid2 size={{ xs: 12, sm: 6, md: 4 }} key={wallet.id}>
@@ -163,7 +209,14 @@ function WalletsArchivePage() {
         </Grid2>
       )}
 
-      {/* Dialog подтверждения разархивации */}
+      <div ref={sentinelRef} />
+
+      {isFetchingNextPage && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
+
       <Dialog open={unarchiveConfirmOpen} onClose={() => setUnarchiveConfirmOpen(false)}>
         <DialogTitle>Разархивировать кошелёк</DialogTitle>
         <DialogContent>
@@ -187,7 +240,6 @@ function WalletsArchivePage() {
         </DialogActions>
       </Dialog>
 
-      {/* Error Dialog */}
       <ErrorDialog
         open={errorDialog.open}
         message={errorDialog.message}
@@ -245,7 +297,11 @@ function WalletCard({ wallet, onUnarchive }: WalletCardProps) {
           sx={{ mb: 2 }}
         />
 
-        <Typography variant="h4" gutterBottom color={wallet.balance >= 0 ? 'success.main' : 'error.main'}>
+        <Typography
+          variant="h4"
+          gutterBottom
+          color={wallet.balance >= 0 ? 'success.main' : 'error.main'}
+        >
           {formatMoney(wallet.balance)}
         </Typography>
 
@@ -260,10 +316,19 @@ function WalletCard({ wallet, onUnarchive }: WalletCardProps) {
               </Typography>
             </Box>
             {wallet.targetDate && (
-              <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ mt: 0.5, display: 'block' }}
+              >
                 До: {formatDate(wallet.targetDate)}
               </Typography>
             )}
+            <LinearProgress
+              variant="determinate"
+              value={progressPercent}
+              sx={{ height: 8, borderRadius: 1, mt: 1 }}
+            />
           </Box>
         )}
 

--- a/FinanceTrack.Client.Browser/src/pages/WalletsPage/WalletsPage.tsx
+++ b/FinanceTrack.Client.Browser/src/pages/WalletsPage/WalletsPage.tsx
@@ -1,12 +1,13 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Box,
   Button,
   Card,
   CardContent,
   Chip,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -27,7 +28,6 @@ import Grid2 from '@mui/material/Grid2';
 import AddIcon from '@mui/icons-material/Add';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import SavingsIcon from '@mui/icons-material/Savings';
-import ArchiveIcon from '@mui/icons-material/Archive';
 
 import Loading from '@/components/Loading';
 
@@ -42,8 +42,10 @@ type Wallet = {
   isArchived: boolean;
 };
 
-type WalletsResponse = {
+type WalletsPage = {
   wallets: Wallet[];
+  nextCursor: string | null;
+  hasMore: boolean;
 };
 
 type CreateWalletPayload = {
@@ -58,28 +60,24 @@ type CreateWalletResponse = {
   id: string;
 };
 
-const fetchWallets = async (): Promise<Wallet[]> => {
-  try {
-    const res = await fetch('/api/finance/Wallets', {
-      credentials: 'include',
-    });
-    if (!res.ok) {
-      throw new Error(`HTTP error! status: ${res.status}`);
-    }
-    const data: WalletsResponse = await res.json();
-    return data.wallets;
-  } catch (e) {
-    console.error('Failed to fetch wallets:', e);
-    throw e;
-  }
+const PAGE_SIZE = 30;
+
+const fetchWallets = async ({ pageParam }: { pageParam: string | null }): Promise<WalletsPage> => {
+  const params = new URLSearchParams();
+  params.append('pageSize', String(PAGE_SIZE));
+  if (pageParam) params.append('afterCursor', pageParam);
+
+  const res = await fetch(`/api/finance/Wallets?${params.toString()}`, {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+  return await res.json();
 };
 
 const createWallet = async (payload: CreateWalletPayload): Promise<CreateWalletResponse> => {
   const res = await fetch('/api/finance/Wallets', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
     body: JSON.stringify(payload),
   });
@@ -121,6 +119,7 @@ type WalletFormState = {
 
 function WalletsPage() {
   const queryClient = useQueryClient();
+  const sentinelRef = useRef<HTMLDivElement>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [formState, setFormState] = useState<WalletFormState>({
     name: '',
@@ -130,11 +129,48 @@ function WalletsPage() {
     targetDate: '',
   });
 
-  const { data: wallets, isLoading, isPending, error } = useQuery({
+  const {
+    data: walletsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    error,
+  } = useInfiniteQuery({
     queryKey: ['wallets'],
     queryFn: fetchWallets,
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.nextCursor : undefined),
     retry: false,
   });
+
+  const wallets = useMemo(() => {
+    const seen = new Set<string>();
+    return (walletsData?.pages ?? [])
+      .flatMap((p) => p.wallets)
+      .filter((w) => {
+        if (seen.has(w.id)) return false;
+        seen.add(w.id);
+        return true;
+      });
+  }, [walletsData]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const createWalletMutation = useMutation({
     mutationFn: createWallet,
@@ -170,7 +206,6 @@ function WalletsPage() {
   };
 
   const handleSubmit = () => {
-    // Валидация
     if (!formState.name.trim()) {
       alert('Введите название кошелька');
       return;
@@ -203,7 +238,7 @@ function WalletsPage() {
 
   const isSavings = formState.walletType === 'Savings';
 
-  if (isLoading || isPending) {
+  if (isLoading) {
     return <Loading />;
   }
 
@@ -217,24 +252,17 @@ function WalletsPage() {
     );
   }
 
-  const activeWallets = wallets?.filter((w) => !w.isArchived) ?? [];
-  const archivedWallets = wallets?.filter((w) => w.isArchived) ?? [];
-
   return (
     <Box sx={{ p: 3 }}>
       <meta name="title" content="Кошельки" />
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Typography variant="h4">Кошельки</Typography>
-        <Button
-          variant="contained"
-          startIcon={<AddIcon />}
-          onClick={handleOpenDialog}
-        >
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleOpenDialog}>
           Создать кошелёк
         </Button>
       </Box>
 
-      {(!wallets || wallets.length === 0) && (
+      {wallets.length === 0 && (
         <Box sx={{ textAlign: 'center', py: 4 }}>
           <Typography variant="h5" gutterBottom>
             У вас пока нет кошельков
@@ -245,33 +273,21 @@ function WalletsPage() {
         </Box>
       )}
 
-      {activeWallets.length > 0 && (
-        <Box sx={{ mb: 4 }}>
-          <Typography variant="h6" gutterBottom sx={{ mb: 2 }}>
-            Активные кошельки
-          </Typography>
-          <Grid2 container spacing={2}>
-            {activeWallets.map((wallet) => (
-              <Grid2 size={{ xs: 12, sm: 6, md: 4 }} key={wallet.id}>
-                <WalletCard wallet={wallet} />
-              </Grid2>
-            ))}
-          </Grid2>
-        </Box>
+      {wallets.length > 0 && (
+        <Grid2 container spacing={2}>
+          {wallets.map((wallet) => (
+            <Grid2 size={{ xs: 12, sm: 6, md: 4 }} key={wallet.id}>
+              <WalletCard wallet={wallet} />
+            </Grid2>
+          ))}
+        </Grid2>
       )}
 
-      {archivedWallets.length > 0 && (
-        <Box>
-          <Typography variant="h6" gutterBottom sx={{ mb: 2, color: 'text.secondary' }}>
-            Архивированные кошельки
-          </Typography>
-          <Grid2 container spacing={2}>
-            {archivedWallets.map((wallet) => (
-              <Grid2 size={{ xs: 12, sm: 6, md: 4 }} key={wallet.id}>
-                <WalletCard wallet={wallet} />
-              </Grid2>
-            ))}
-          </Grid2>
+      <div ref={sentinelRef} />
+
+      {isFetchingNextPage && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+          <CircularProgress size={24} />
         </Box>
       )}
 
@@ -332,9 +348,9 @@ function WalletsPage() {
                   onChange={(e) => setFormState({ ...formState, targetAmount: e.target.value })}
                   fullWidth
                   required
-                  inputProps={{ min: 0.01, step: 0.01 }}
-                  InputProps={{
-                    endAdornment: <InputAdornment position="end">₽</InputAdornment>,
+                  slotProps={{
+                    htmlInput: { min: 0.01, step: 0.01 },
+                    input: { endAdornment: <InputAdornment position="end">₽</InputAdornment> },
                   }}
                 />
 
@@ -344,8 +360,10 @@ function WalletsPage() {
                   value={formState.targetDate}
                   onChange={(e) => setFormState({ ...formState, targetDate: e.target.value })}
                   fullWidth
-                  InputLabelProps={{ shrink: true }}
-                  inputProps={{ min: new Date().toISOString().split('T')[0] }}
+                  slotProps={{
+                    inputLabel: { shrink: true },
+                    htmlInput: { min: new Date().toISOString().split('T')[0] },
+                  }}
                 />
               </>
             )}
@@ -378,35 +396,19 @@ function WalletCard({ wallet }: WalletCardProps) {
       ? Math.min((wallet.balance / wallet.targetAmount) * 100, 100)
       : 0;
 
-  const handleCardClick = () => {
-    navigate(`/wallets/${wallet.id}`);
-  };
-
   return (
     <Card
       variant="outlined"
-      onClick={handleCardClick}
+      onClick={() => navigate(`/wallets/${wallet.id}`)}
       sx={{
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        opacity: wallet.isArchived ? 0.6 : 1,
-        position: 'relative',
         cursor: 'pointer',
-        '&:hover': {
-          boxShadow: 3,
-        },
+        '&:hover': { boxShadow: 3 },
         transition: 'box-shadow 0.2s',
       }}
     >
-      {wallet.isArchived && (
-        <Chip
-          icon={<ArchiveIcon />}
-          label="Архив"
-          size="small"
-          sx={{ position: 'absolute', top: 8, right: 8 }}
-        />
-      )}
       <CardContent sx={{ flexGrow: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
           {isSavings ? (
@@ -426,7 +428,11 @@ function WalletCard({ wallet }: WalletCardProps) {
           sx={{ mb: 2 }}
         />
 
-        <Typography variant="h4" gutterBottom color={wallet.balance >= 0 ? 'success.main' : 'error.main'}>
+        <Typography
+          variant="h4"
+          gutterBottom
+          color={wallet.balance >= 0 ? 'success.main' : 'error.main'}
+        >
           {formatMoney(wallet.balance)}
         </Typography>
 

--- a/FinanceTrack.Finance/Directory.Packages.props
+++ b/FinanceTrack.Finance/Directory.Packages.props
@@ -1,48 +1,55 @@
 ﻿<Project>
-  <ItemGroup>
-    <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
-    <PackageVersion Include="Ardalis.HttpClientTestExtensions" Version="4.2.0" />
-    <PackageVersion Include="Ardalis.ListStartupServices" Version="1.1.4" />
-    <PackageVersion Include="Ardalis.Result" Version="10.1.0" />
-    <PackageVersion Include="Ardalis.Result.AspNetCore" Version="10.1.0" />
-    <PackageVersion Include="Ardalis.SharedKernel" Version="3.0.1" />
-    <PackageVersion Include="Ardalis.SmartEnum" Version="8.2.0" />
-    <PackageVersion Include="Ardalis.Specification" Version="9.2.0" />
-    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Docnet.Core" Version="2.6.0" />
-    <PackageVersion Include="FastEndpoints" Version="6.2.0" />
-    <PackageVersion Include="FastEndpoints.ApiExplorer" Version="2.2.0" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="6.2.0" />
-    <PackageVersion Include="FastEndpoints.Swagger.Swashbuckle" Version="2.2.0" />
-    <PackageVersion Include="MailKit" Version="4.13.0" />
-    <PackageVersion Include="MediatR" Version="12.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="ReportGenerator" Version="5.4.8" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="SQLite" Version="3.13.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
+        <PackageVersion Include="Ardalis.HttpClientTestExtensions" Version="4.2.0" />
+        <PackageVersion Include="Ardalis.ListStartupServices" Version="1.1.4" />
+        <PackageVersion Include="Ardalis.Result" Version="10.1.0" />
+        <PackageVersion Include="Ardalis.Result.AspNetCore" Version="10.1.0" />
+        <PackageVersion Include="Ardalis.SharedKernel" Version="3.0.1" />
+        <PackageVersion Include="Ardalis.SmartEnum" Version="8.2.0" />
+        <PackageVersion Include="Ardalis.Specification" Version="9.2.0" />
+        <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
+        <PackageVersion Include="Azure.Identity" Version="1.13.1" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+        <PackageVersion Include="Docnet.Core" Version="2.6.0" />
+        <PackageVersion Include="FastEndpoints" Version="6.2.0" />
+        <PackageVersion Include="FastEndpoints.ApiExplorer" Version="2.2.0" />
+        <PackageVersion Include="FastEndpoints.Swagger" Version="6.2.0" />
+        <PackageVersion Include="FastEndpoints.Swagger.Swashbuckle" Version="2.2.0" />
+        <PackageVersion Include="MailKit" Version="4.16.0" />
+        <PackageVersion Include="MediatR" Version="12.5.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.11" />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+        <PackageVersion
+            Include="Microsoft.Extensions.Options.ConfigurationExtensions"
+            Version="9.0.6"
+        />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageVersion
+            Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets"
+            Version="1.22.1"
+        />
+        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+        <PackageVersion Include="NSubstitute" Version="5.3.0" />
+        <PackageVersion Include="ReportGenerator" Version="5.4.8" />
+        <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+        <PackageVersion Include="Shouldly" Version="4.3.0" />
+        <PackageVersion Include="SQLite" Version="3.13.0" />
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+        <PackageVersion Include="xunit" Version="2.9.3" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+        <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
+        <PackageVersion Include="MR.AspNetCore.Pagination" Version="3.1.0" />
+    </ItemGroup>
 </Project>

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Config/PaginationOptionsSetup.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Config/PaginationOptionsSetup.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MR.AspNetCore.Pagination;
+
+namespace FinanceTrack.Finance.Infrastructure.Data.Config;
+
+public class PaginationOptionsSetup : IConfigureOptions<PaginationOptions>
+{
+    public void Configure(PaginationOptions options)
+    {
+        options.FirstQueryParameterName = "first";
+        options.BeforeQueryParameterName = "last";
+        options.AfterQueryParameterName = "after";
+        options.LastQueryParameterName = "last";
+        options.PageQueryParameterName = "page";
+        options.PageSizeQueryParameterName = "pageSize"; // Параметр запроса для размера страницы
+
+        options.DefaultSize = 30; // Размер страницы по умолчанию
+        options.MaxSize = 100; // Максимальный допустимый размер страницы через pageSize
+        options.CanChangeSizeFromQuery = true; // Разрешать изменение размера страницы через параметры запроса
+    }
+}

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Queries/PaginationCursor.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Queries/PaginationCursor.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using System.Text;
+
+namespace FinanceTrack.Finance.Infrastructure.Data.Queries;
+
+internal static class PaginationCursor
+{
+    public static string Encode(DateOnly operationDate, DateTime createdAtUtc, Guid id)
+    {
+        var raw = $"{operationDate:yyyy-MM-dd}|{createdAtUtc:O}|{id}";
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(raw));
+    }
+
+    public static bool TryDecode(
+        string cursor,
+        out DateOnly operationDate,
+        out DateTime createdAtUtc,
+        out Guid id
+    )
+    {
+        operationDate = default;
+        createdAtUtc = default;
+        id = default;
+
+        try
+        {
+            var raw = Encoding.UTF8.GetString(Convert.FromBase64String(cursor));
+            var parts = raw.Split('|');
+            if (parts.Length != 3)
+                return false;
+
+            if (!DateOnly.TryParseExact(parts[0], "yyyy-MM-dd", out operationDate))
+                return false;
+            if (
+                !DateTime.TryParse(
+                    parts[1],
+                    null,
+                    DateTimeStyles.RoundtripKind,
+                    out createdAtUtc
+                )
+            )
+                return false;
+            if (!Guid.TryParse(parts[2], out id))
+                return false;
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Queries/UserWalletListQueryService.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Queries/UserWalletListQueryService.cs
@@ -1,0 +1,62 @@
+﻿using FinanceTrack.Finance.Core.WalletAggregate;
+using FinanceTrack.Finance.UseCases.Wallets;
+using FinanceTrack.Finance.UseCases.Wallets.List;
+using MR.AspNetCore.Pagination;
+
+namespace FinanceTrack.Finance.Infrastructure.Data.Queries;
+
+public class UserWalletListQueryService(AppDbContext dbContext, IPaginationService service)
+    : IUserWalletListQueryService
+{
+    public async Task<WalletPageDto> ListAsync(
+        string userId,
+        bool isArchived,
+        string? afterCursor,
+        int pageSize,
+        CancellationToken cancel
+    )
+    {
+        var query = dbContext
+            .Wallets.AsNoTracking()
+            .Where(w => w.UserId == userId && w.IsArchived == isArchived);
+
+        if (
+            afterCursor != null
+            && WalletPaginationCursor.TryDecode(afterCursor, out var lastCreatedAt, out var lastId)
+        )
+        {
+            query = query.Where(w =>
+                w.CreatedAtUtc > lastCreatedAt || (w.CreatedAtUtc == lastCreatedAt && w.Id > lastId)
+            );
+        }
+
+        var page = await service.KeysetPaginateAsync<Wallet, Wallet>(
+            source: query,
+            builderAction: b => b.Ascending(w => w.CreatedAtUtc).Ascending(w => w.Id),
+            getReferenceAsync: _ => Task.FromResult<Wallet?>(null), // Намеренно сводим к null, т.к. курсор уже предоставляет все необходимые данные для пагинации
+            map: q => q,
+            queryModel: new KeysetQueryModel { Size = pageSize }
+        );
+
+        var last = page.Data.LastOrDefault();
+        var nextCursor =
+            page.HasNext && last != null
+                ? WalletPaginationCursor.Encode(last.CreatedAtUtc, last.Id)
+                : null;
+
+        var dtos = page
+            .Data.Select(w => new WalletDto(
+                w.Id,
+                w.Name,
+                w.WalletType.Name,
+                w.Balance,
+                w.AllowNegativeBalance,
+                w.TargetAmount,
+                w.TargetDate,
+                w.IsArchived
+            ))
+            .ToList();
+
+        return new WalletPageDto(dtos, nextCursor, page.HasNext);
+    }
+}

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Queries/WalletPaginationCursor.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Queries/WalletPaginationCursor.cs
@@ -1,0 +1,38 @@
+﻿using System.Globalization;
+using System.Text;
+
+namespace FinanceTrack.Finance.Infrastructure.Data.Queries;
+
+internal static class WalletPaginationCursor
+{
+    public static string Encode(DateTime createdAtUtc, Guid id)
+    {
+        var raw = $"{createdAtUtc:O}|{id}";
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(raw));
+    }
+
+    public static bool TryDecode(string cursor, out DateTime createdAtUtc, out Guid id)
+    {
+        createdAtUtc = default;
+        id = default;
+
+        try
+        {
+            var raw = Encoding.UTF8.GetString(Convert.FromBase64String(cursor));
+            var parts = raw.Split('|');
+            if (parts.Length != 2)
+                return false;
+
+            if (!DateTime.TryParse(parts[0], null, DateTimeStyles.RoundtripKind, out createdAtUtc))
+                return false;
+            if (!Guid.TryParse(parts[1], out id))
+                return false;
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Queries/WalletTransactionListQueryService.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/Data/Queries/WalletTransactionListQueryService.cs
@@ -1,0 +1,97 @@
+﻿using FinanceTrack.Finance.Core.FinancialTransactionAggregate;
+using FinanceTrack.Finance.UseCases.FinancialTransactions;
+using FinanceTrack.Finance.UseCases.FinancialTransactions.List;
+using MR.AspNetCore.Pagination;
+
+namespace FinanceTrack.Finance.Infrastructure.Data.Queries;
+
+public class WalletTransactionListQueryService(AppDbContext dbContext, IPaginationService service)
+    : IWalletTransactionListQueryService
+{
+    public async Task<FinancialTransactionPageDto> ListAsync(
+        string userId,
+        Guid walletId,
+        DateOnly from,
+        DateOnly to,
+        string? afterCursor,
+        int pageSize,
+        CancellationToken cancel
+    )
+    {
+        var query = dbContext
+            .FinancialTransactions.AsNoTracking()
+            .Where(t => t.UserId == userId && t.WalletId == walletId)
+            .Where(t => t.OperationDate >= from && t.OperationDate <= to);
+
+        if (
+            afterCursor != null
+            && PaginationCursor.TryDecode(
+                afterCursor,
+                out var lastDate,
+                out var lastCreatedAt,
+                out var lastId
+            )
+        )
+        {
+            query = query.Where(t =>
+                t.OperationDate < lastDate
+                || (t.OperationDate == lastDate && t.CreatedAtUtc < lastCreatedAt)
+                || (t.OperationDate == lastDate && t.CreatedAtUtc == lastCreatedAt && t.Id < lastId)
+            );
+        }
+
+        var page = await service.KeysetPaginateAsync<FinancialTransaction, FinancialTransaction>(
+            source: query,
+            builderAction: b =>
+                b.Descending(t => t.OperationDate)
+                    .Descending(t => t.CreatedAtUtc)
+                    .Descending(t => t.Id),
+            getReferenceAsync: _ => Task.FromResult<FinancialTransaction?>(null), // reference заведомо сводим к null, т.к. передаваемый курсор уже даёт все необходимые данные для построения страницы
+            map: q => q,
+            queryModel: new KeysetQueryModel { Size = pageSize }
+        );
+
+        var last = page.Data.LastOrDefault();
+        var nextCursor =
+            page.HasNext && last != null
+                ? PaginationCursor.Encode(last.OperationDate, last.CreatedAtUtc, last.Id)
+                : null;
+
+        var transactions = await EnrichAsync(page.Data, cancel);
+        return new FinancialTransactionPageDto(transactions, nextCursor, page.HasNext);
+    }
+
+    private async Task<IReadOnlyList<FinancialTransactionDto>> EnrichAsync(
+        IReadOnlyList<FinancialTransaction> transactions,
+        CancellationToken cancel
+    )
+    {
+        var relatedIds = transactions
+            .Where(t => t.RelatedTransactionId.HasValue)
+            .Select(t => t.RelatedTransactionId!.Value)
+            .Distinct()
+            .ToList();
+
+        var relatedTransactions = relatedIds.Any()
+            ? await dbContext
+                .FinancialTransactions.AsNoTracking()
+                .Where(t => relatedIds.Contains(t.Id))
+                .ToDictionaryAsync(t => t.Id, cancel)
+            : [];
+
+        var relatedWalletIds = relatedTransactions.Any()
+            ? relatedTransactions.Values.Select(t => t.WalletId).Distinct().ToList()
+            : [];
+
+        var relatedWallets = relatedWalletIds.Any()
+            ? await dbContext
+                .Wallets.AsNoTracking()
+                .Where(w => relatedWalletIds.Contains(w.Id))
+                .ToDictionaryAsync(w => w.Id, cancel)
+            : [];
+
+        return transactions
+            .Select(t => FinancialTransactionDto.FromEntity(t, relatedTransactions, relatedWallets))
+            .ToList();
+    }
+}

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/FinanceTrack.Finance.Infrastructure.csproj
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/FinanceTrack.Finance.Infrastructure.csproj
@@ -1,28 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup></PropertyGroup>
-  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
-  <ItemGroup>
-    <PackageReference Include="Ardalis.SharedKernel" />
-    <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" />
-    <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Docnet.Core" />
-    <PackageReference Include="MailKit" />
-    <PackageReference Include="MediatR" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="SQLite" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\FinanceTrack.Finance.Core\FinanceTrack.Finance.Core.csproj" />
-    <ProjectReference Include="..\FinanceTrack.Finance.UseCases\FinanceTrack.Finance.UseCases.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Data\Migrations\" />
-  </ItemGroup>
+    <PropertyGroup></PropertyGroup>
+    <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
+    <ItemGroup>
+        <PackageReference Include="Ardalis.SharedKernel" />
+        <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" />
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="Docnet.Core" />
+        <PackageReference Include="MailKit" />
+        <PackageReference Include="MediatR" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+        <PackageReference Include="SQLite" />
+        <PackageReference Include="MR.AspNetCore.Pagination" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\FinanceTrack.Finance.Core\FinanceTrack.Finance.Core.csproj" />
+        <ProjectReference Include="..\FinanceTrack.Finance.UseCases\FinanceTrack.Finance.UseCases.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Data\Migrations\" />
+    </ItemGroup>
 </Project>

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using FinanceTrack.Finance.Core.Interfaces;
 using FinanceTrack.Finance.Core.Services;
 using FinanceTrack.Finance.Infrastructure.Data;
+using FinanceTrack.Finance.Infrastructure.Data.Config;
 using FinanceTrack.Finance.Infrastructure.Data.Queries;
 using FinanceTrack.Finance.Infrastructure.PdfImport;
 using FinanceTrack.Finance.UseCases.Analytics;
+using FinanceTrack.Finance.UseCases.FinancialTransactions.List;
 using FinanceTrack.Finance.UseCases.FullTextSearch;
 using FinanceTrack.Finance.UseCases.ImportTransactions;
 using FinanceTrack.Finance.UseCases.Wallets;
@@ -46,7 +48,8 @@ public static class InfrastructureServiceExtensions
             .AddScoped<
                 IGlobalFullTextSearchQueryService,
                 GlobalFullTextSearchParallelQueryService
-            >();
+            >()
+            .AddScoped<IWalletTransactionListQueryService, WalletTransactionListQueryService>();
 
         logger.LogInformation("{Project} services registered", "Infrastructure");
 

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Infrastructure/InfrastructureServiceExtensions.cs
@@ -9,6 +9,7 @@ using FinanceTrack.Finance.UseCases.FinancialTransactions.List;
 using FinanceTrack.Finance.UseCases.FullTextSearch;
 using FinanceTrack.Finance.UseCases.ImportTransactions;
 using FinanceTrack.Finance.UseCases.Wallets;
+using FinanceTrack.Finance.UseCases.Wallets.List;
 
 namespace FinanceTrack.Finance.Infrastructure;
 
@@ -49,7 +50,8 @@ public static class InfrastructureServiceExtensions
                 IGlobalFullTextSearchQueryService,
                 GlobalFullTextSearchParallelQueryService
             >()
-            .AddScoped<IWalletTransactionListQueryService, WalletTransactionListQueryService>();
+            .AddScoped<IWalletTransactionListQueryService, WalletTransactionListQueryService>()
+            .AddScoped<IUserWalletListQueryService, UserWalletListQueryService>();
 
         logger.LogInformation("{Project} services registered", "Infrastructure");
 

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/FinancialTransactionDto.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/FinancialTransactionDto.cs
@@ -1,4 +1,8 @@
-﻿namespace FinanceTrack.Finance.UseCases.FinancialTransactions;
+﻿using FinanceTrack.Finance.Core.FinancialTransactionAggregate;
+using FinanceTrack.Finance.Core.WalletAggregate;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace FinanceTrack.Finance.UseCases.FinancialTransactions;
 
 public sealed record FinancialTransactionDto(
     Guid Id,
@@ -14,4 +18,43 @@ public sealed record FinancialTransactionDto(
     Guid? RelatedWalletId = null,
     string? RelatedWalletName = null,
     string? WalletName = null
-);
+)
+{
+    public static FinancialTransactionDto FromEntity(
+        FinancialTransaction t,
+        Dictionary<Guid, FinancialTransaction> relatedTransactions,
+        Dictionary<Guid, Wallet> relatedWallets
+    )
+    {
+        Guid? relatedWalletId = null;
+        string? relatedWalletName = null;
+
+        if (
+            t.RelatedTransactionId.HasValue
+            && relatedTransactions.TryGetValue(
+                t.RelatedTransactionId.Value,
+                out var relatedTransaction
+            )
+        )
+        {
+            relatedWalletId = relatedTransaction.WalletId;
+            if (relatedWallets.TryGetValue(relatedTransaction.WalletId, out var relatedWallet))
+                relatedWalletName = relatedWallet.Name;
+        }
+
+        return new FinancialTransactionDto(
+            t.Id,
+            t.WalletId,
+            t.Name,
+            t.Description,
+            t.Amount,
+            t.OperationDate,
+            t.TransactionType.Name,
+            t.CategoryId,
+            t.RelatedTransactionId,
+            t.RecurringTransactionId,
+            relatedWalletId,
+            relatedWalletName
+        );
+    }
+};

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/List/FinancialTransactionPageDto.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/List/FinancialTransactionPageDto.cs
@@ -1,0 +1,7 @@
+﻿namespace FinanceTrack.Finance.UseCases.FinancialTransactions.List;
+
+public sealed record FinancialTransactionPageDto(
+    IReadOnlyList<FinancialTransactionDto> Transactions,
+    string? NextCursor,
+    bool HasMore
+);

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/List/IWalletTransactionListQueryService.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/List/IWalletTransactionListQueryService.cs
@@ -1,0 +1,14 @@
+﻿namespace FinanceTrack.Finance.UseCases.FinancialTransactions.List;
+
+public interface IWalletTransactionListQueryService
+{
+    Task<FinancialTransactionPageDto> ListAsync(
+        string userId,
+        Guid walletId,
+        DateOnly from,
+        DateOnly to,
+        string? afterCursor, // курсор клиента для пагинации. Если null - первая страница.
+        int pageSize,
+        CancellationToken cancel
+    );
+}

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/List/ListWalletTransactionsHandler.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/List/ListWalletTransactionsHandler.cs
@@ -1,122 +1,35 @@
-﻿using FinanceTrack.Finance.Core.FinancialTransactionAggregate;
-using FinanceTrack.Finance.Core.FinancialTransactionAggregate.Specifications;
-using FinanceTrack.Finance.Core.WalletAggregate;
+﻿using FinanceTrack.Finance.Core.WalletAggregate;
 using FinanceTrack.Finance.Core.WalletAggregate.Specifications;
 
 namespace FinanceTrack.Finance.UseCases.FinancialTransactions.List;
 
 public sealed class ListWalletTransactionsHandler(
-    IReadRepository<FinancialTransaction> transactionRepo,
+    IWalletTransactionListQueryService transactionListService,
     IReadRepository<Wallet> walletRepo
-) : IQueryHandler<ListWalletTransactionsQuery, Result<IReadOnlyList<FinancialTransactionDto>>>
+) : IQueryHandler<ListWalletTransactionsQuery, Result<FinancialTransactionPageDto>>
 {
-    public async Task<Result<IReadOnlyList<FinancialTransactionDto>>> Handle(
+    public async Task<Result<FinancialTransactionPageDto>> Handle(
         ListWalletTransactionsQuery request,
-        CancellationToken ct
+        CancellationToken cancel
     )
     {
         var walletSpec = new WalletByIdSpec(request.WalletId);
-        var wallet = await walletRepo.FirstOrDefaultAsync(walletSpec, ct);
+        var wallet = await walletRepo.FirstOrDefaultAsync(walletSpec, cancel);
         if (wallet is null)
             return Result.NotFound();
         if (!string.Equals(wallet.UserId, request.UserId, StringComparison.Ordinal))
             return Result.Forbidden();
 
-        FinancialTransactionType? typeFilter = null;
-        if (!string.IsNullOrWhiteSpace(request.Type))
-        {
-            if (
-                !FinancialTransactionType.TryFromName(
-                    request.Type,
-                    ignoreCase: true,
-                    out var parsed
-                )
-            )
-                return Result.Error($"Invalid transaction type: {request.Type}");
-            typeFilter = parsed;
-        }
-
-        var spec = new WalletTransactionsSpec(
+        var transactionsResult = await transactionListService.ListAsync(
             request.UserId,
             request.WalletId,
-            typeFilter,
             request.From,
-            request.To
+            request.To,
+            request.AfterCursor,
+            request.PageSize,
+            cancel
         );
 
-        var transactions = await transactionRepo.ListAsync(spec, ct);
-
-        // Processing related transactions
-        var relatedTransactionIds = transactions
-            .Where(t => t.RelatedTransactionId.HasValue)
-            .Select(t => t.RelatedTransactionId!.Value)
-            .Distinct()
-            .ToList();
-
-        Dictionary<Guid, FinancialTransaction> relatedTransactions = new();
-        if (relatedTransactionIds.Any())
-        {
-            var relatedSpec = new TransactionsByIdsSpec(relatedTransactionIds);
-            var related = await transactionRepo.ListAsync(relatedSpec, ct);
-            relatedTransactions = related.ToDictionary(t => t.Id);
-        }
-
-        var relatedWalletIds = relatedTransactions
-            .Values.Select(t => t.WalletId)
-            .Distinct()
-            .ToList();
-
-        Dictionary<Guid, Wallet> relatedWallets = new();
-        if (relatedWalletIds.Any())
-        {
-            var wallets = await walletRepo.ListAsync(new WalletsByIdsSpec(relatedWalletIds), ct);
-            relatedWallets = wallets.ToDictionary(w => w.Id);
-        }
-        // End Processing related transactions
-
-        IReadOnlyList<FinancialTransactionDto> dtos = transactions
-            .Select(t =>
-            {
-                Guid? relatedWalletId = null;
-                string? relatedWalletName = null;
-
-                if (
-                    t.RelatedTransactionId.HasValue
-                    && relatedTransactions.TryGetValue(
-                        t.RelatedTransactionId.Value,
-                        out var relatedTransaction
-                    )
-                )
-                {
-                    relatedWalletId = relatedTransaction.WalletId;
-                    if (
-                        relatedWallets.TryGetValue(
-                            relatedTransaction.WalletId,
-                            out var relatedWallet
-                        )
-                    )
-                    {
-                        relatedWalletName = relatedWallet.Name;
-                    }
-                }
-
-                return new FinancialTransactionDto(
-                    t.Id,
-                    t.WalletId,
-                    t.Name,
-                    t.Description,
-                    t.Amount,
-                    t.OperationDate,
-                    t.TransactionType.Name,
-                    t.CategoryId,
-                    t.RelatedTransactionId,
-                    t.RecurringTransactionId,
-                    relatedWalletId,
-                    relatedWalletName
-                );
-            })
-            .ToList();
-
-        return Result.Success(dtos);
+        return transactionsResult;
     }
 }

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/List/ListWalletTransactionsQuery.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/FinancialTransactions/List/ListWalletTransactionsQuery.cs
@@ -1,9 +1,10 @@
-namespace FinanceTrack.Finance.UseCases.FinancialTransactions.List;
+﻿namespace FinanceTrack.Finance.UseCases.FinancialTransactions.List;
 
 public sealed record ListWalletTransactionsQuery(
     string UserId,
     Guid WalletId,
-    string? Type,
-    DateOnly? From,
-    DateOnly? To
-) : IQuery<Result<IReadOnlyList<FinancialTransactionDto>>>;
+    DateOnly From,
+    DateOnly To,
+    string? AfterCursor,
+    int PageSize
+) : IQuery<Result<FinancialTransactionPageDto>>;

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/IUserWalletListQueryService.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/IUserWalletListQueryService.cs
@@ -1,0 +1,12 @@
+﻿namespace FinanceTrack.Finance.UseCases.Wallets.List;
+
+public interface IUserWalletListQueryService
+{
+    Task<WalletPageDto> ListAsync(
+        string userId,
+        bool isArchived,
+        string? afterCursor,
+        int pageSize,
+        CancellationToken cancel
+    );
+}

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/ListUserArchiveWalletsHandler.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/ListUserArchiveWalletsHandler.cs
@@ -1,35 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FinanceTrack.Finance.Core.WalletAggregate;
-using FinanceTrack.Finance.Core.WalletAggregate.Specifications;
+﻿namespace FinanceTrack.Finance.UseCases.Wallets.List;
 
-namespace FinanceTrack.Finance.UseCases.Wallets.List;
-
-public sealed class ListUserArchiveWalletsHandler(IRepository<Wallet> repo)
-    : IQueryHandler<ListUserArchiveWalletsQuery, IReadOnlyList<WalletDto>>
+public sealed class ListUserArchiveWalletsHandler(IUserWalletListQueryService walletListService)
+    : IQueryHandler<ListUserArchiveWalletsQuery, Result<WalletPageDto>>
 {
-    public async Task<IReadOnlyList<WalletDto>> Handle(
+    public async Task<Result<WalletPageDto>> Handle(
         ListUserArchiveWalletsQuery request,
         CancellationToken ct
     )
     {
-        var spec = new UserArchiveWalletsSpec(request.userId);
-        var wallets = await repo.ListAsync(spec, ct);
-
-        return wallets
-            .Select(w => new WalletDto(
-                w.Id,
-                w.Name,
-                w.WalletType.Name,
-                w.Balance,
-                w.AllowNegativeBalance,
-                w.TargetAmount,
-                w.TargetDate,
-                w.IsArchived
-            ))
-            .ToList();
+        var page = await walletListService.ListAsync(
+            request.UserId,
+            isArchived: true,
+            request.AfterCursor,
+            request.PageSize,
+            ct
+        );
+        return Result.Success(page);
     }
 }

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/ListUserArchiveWalletsQuery.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/ListUserArchiveWalletsQuery.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace FinanceTrack.Finance.UseCases.Wallets.List;
 
-namespace FinanceTrack.Finance.UseCases.Wallets.List;
-
-public sealed record ListUserArchiveWalletsQuery(string userId) : IQuery<IReadOnlyList<WalletDto>>;
+public sealed record ListUserArchiveWalletsQuery(string UserId, string? AfterCursor, int PageSize)
+    : IQuery<Result<WalletPageDto>>;

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/ListUserWalletsHandler.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/ListUserWalletsHandler.cs
@@ -1,30 +1,20 @@
-﻿using FinanceTrack.Finance.Core.WalletAggregate;
-using FinanceTrack.Finance.Core.WalletAggregate.Specifications;
+﻿namespace FinanceTrack.Finance.UseCases.Wallets.List;
 
-namespace FinanceTrack.Finance.UseCases.Wallets.List;
-
-public sealed class ListUserWalletsHandler(IReadRepository<Wallet> repo)
-    : IQueryHandler<ListUserWalletsQuery, IReadOnlyList<WalletDto>>
+public sealed class ListUserWalletsHandler(IUserWalletListQueryService walletListService)
+    : IQueryHandler<ListUserWalletsQuery, Result<WalletPageDto>>
 {
-    public async Task<IReadOnlyList<WalletDto>> Handle(
+    public async Task<Result<WalletPageDto>> Handle(
         ListUserWalletsQuery request,
         CancellationToken ct
     )
     {
-        var spec = new UserActiveWalletsSpec(request.UserId);
-        var wallets = await repo.ListAsync(spec, ct);
-
-        return wallets
-            .Select(w => new WalletDto(
-                w.Id,
-                w.Name,
-                w.WalletType.Name,
-                w.Balance,
-                w.AllowNegativeBalance,
-                w.TargetAmount,
-                w.TargetDate,
-                w.IsArchived
-            ))
-            .ToList();
+        var page = await walletListService.ListAsync(
+            request.UserId,
+            isArchived: false,
+            request.AfterCursor,
+            request.PageSize,
+            ct
+        );
+        return Result.Success(page);
     }
 }

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/ListUserWalletsQuery.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/ListUserWalletsQuery.cs
@@ -1,4 +1,4 @@
-namespace FinanceTrack.Finance.UseCases.Wallets.List;
+﻿namespace FinanceTrack.Finance.UseCases.Wallets.List;
 
-public sealed record ListUserWalletsQuery(string UserId)
-    : IQuery<IReadOnlyList<WalletDto>>;
+public sealed record ListUserWalletsQuery(string UserId, string? AfterCursor, int PageSize)
+    : IQuery<Result<WalletPageDto>>;

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/WalletPageDto.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.UseCases/Wallets/List/WalletPageDto.cs
@@ -1,0 +1,7 @@
+﻿namespace FinanceTrack.Finance.UseCases.Wallets.List;
+
+public sealed record WalletPageDto(
+    IReadOnlyList<WalletDto> Wallets,
+    string? NextCursor,
+    bool HasMore
+);

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/Configurations/ServiceConfigs.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/Configurations/ServiceConfigs.cs
@@ -2,6 +2,7 @@
 using Ardalis.GuardClauses;
 using FinanceTrack.Finance.Core.Interfaces;
 using FinanceTrack.Finance.Infrastructure;
+using FinanceTrack.Finance.Infrastructure.Data.Config;
 using FinanceTrack.Finance.Infrastructure.Email;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.Tokens;
@@ -16,8 +17,10 @@ public static class ServiceConfigs
         WebApplicationBuilder builder
     )
     {
-        builder.Services.AddHealthChecks();
+        services.AddHealthChecks();
 
+        services.AddPagination();
+        services.ConfigureOptions<PaginationOptionsSetup>();
         services.AddInfrastructureServices(builder.Configuration, logger).AddMediatrConfigs();
 
         if (builder.Environment.IsDevelopment())

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/FinanceTrack.Finance.Web.csproj
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/FinanceTrack.Finance.Web.csproj
@@ -31,5 +31,6 @@
     </ItemGroup>
     <ItemGroup>
         <Folder Include="FinancialTransactions\Expenses\" />
+        <Folder Include="FinancialTransactions\Meta\" />
     </ItemGroup>
 </Project>

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/FinancialTransactions/ListWalletTransactions.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/FinancialTransactions/ListWalletTransactions.cs
@@ -1,7 +1,9 @@
 ﻿using FinanceTrack.Finance.UseCases.FinancialTransactions.List;
 using FinanceTrack.Finance.Web.Extensions;
+using FinanceTrack.Finance.Web.Transactions;
+using FluentValidation;
 
-namespace FinanceTrack.Finance.Web.Transactions;
+namespace FinanceTrack.Finance.Web.FinancialTransactions;
 
 public class ListWalletTransactionsRequest
 {
@@ -9,18 +11,33 @@ public class ListWalletTransactionsRequest
     public Guid WalletId { get; set; }
 
     [QueryParam]
-    public string? Type { get; set; }
+    public DateOnly From { get; set; }
 
     [QueryParam]
-    public DateOnly? From { get; set; }
+    public DateOnly To { get; set; }
 
     [QueryParam]
-    public DateOnly? To { get; set; }
+    public string? AfterCursor { get; set; }
+
+    [QueryParam]
+    public int PageSize { get; set; }
+}
+
+public class ListWalletTransactionsValidator : Validator<ListWalletTransactionsRequest>
+{
+    public ListWalletTransactionsValidator()
+    {
+        RuleFor(r => r.WalletId).NotEmpty();
+        RuleFor(r => r.From).LessThanOrEqualTo(r => r.To);
+        RuleFor(r => r.PageSize).GreaterThan(0).LessThanOrEqualTo(100);
+    }
 }
 
 public class ListWalletTransactionsResponse
 {
     public List<FinancialTransactionRecord> Transactions { get; set; } = [];
+    public string? NextCursor { get; set; }
+    public bool HasMore { get; set; }
 }
 
 public class ListWalletTransactions(IMediator mediator)
@@ -32,45 +49,54 @@ public class ListWalletTransactions(IMediator mediator)
         Roles("user");
     }
 
-    public override async Task HandleAsync(ListWalletTransactionsRequest req, CancellationToken ct)
+    public override async Task HandleAsync(
+        ListWalletTransactionsRequest req,
+        CancellationToken cancel
+    )
     {
         var userId = User.GetUserId();
         if (string.IsNullOrWhiteSpace(userId))
         {
-            await SendUnauthorizedAsync(ct);
+            await SendUnauthorizedAsync(cancel);
             return;
         }
 
         var query = new ListWalletTransactionsQuery(
             userId,
             req.WalletId,
-            req.Type,
             req.From,
-            req.To
+            req.To,
+            req.AfterCursor,
+            req.PageSize
         );
-        var result = await mediator.Send(query, ct);
+        var result = await mediator.Send(query, cancel);
 
-        if (await this.SendResultIfNotOk(result, ct))
+        if (await this.SendResultIfNotOk(result, cancel))
             return;
 
-        Response = new ListWalletTransactionsResponse
-        {
-            Transactions = result
-                .Value.Select(t => new FinancialTransactionRecord(
-                    t.Id,
-                    t.WalletId,
-                    t.Name,
-                    t.Description,
-                    t.Amount,
-                    t.OperationDate,
-                    t.Type,
-                    t.CategoryId,
-                    t.RelatedTransactionId,
-                    t.RecurringTransactionId,
-                    t.RelatedWalletId,
-                    t.RelatedWalletName
-                ))
-                .ToList(),
-        };
+        await SendOkAsync(
+            new ListWalletTransactionsResponse
+            {
+                Transactions = result
+                    .Value.Transactions.Select(t => new FinancialTransactionRecord(
+                        t.Id,
+                        t.WalletId,
+                        t.Name,
+                        t.Description,
+                        t.Amount,
+                        t.OperationDate,
+                        t.Type,
+                        t.CategoryId,
+                        t.RelatedTransactionId,
+                        t.RecurringTransactionId,
+                        t.RelatedWalletId,
+                        t.RelatedWalletName
+                    ))
+                    .ToList(),
+                NextCursor = result.Value.NextCursor,
+                HasMore = result.Value.HasMore,
+            },
+            cancel
+        );
     }
 }

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/FinancialTransactions/Meta/GetWalletTransactionsDateRange.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/FinancialTransactions/Meta/GetWalletTransactionsDateRange.cs
@@ -1,0 +1,54 @@
+﻿using FinanceTrack.Finance.UseCases.Analytics;
+using FinanceTrack.Finance.UseCases.Analytics.Dto;
+using FinanceTrack.Finance.Web.Extensions;
+using FluentValidation;
+
+namespace FinanceTrack.Finance.Web.FinancialTransactions.Meta;
+
+public sealed class GetWalletTransactionsDateRangeRequest
+{
+    public const string Route = "/Wallets/{WalletId:guid}/Transactions/Meta/DateRange";
+    public Guid WalletId { get; set; }
+}
+
+public class GetWalletTransactionsDateRangeValidator
+    : Validator<GetWalletTransactionsDateRangeRequest>
+{
+    public GetWalletTransactionsDateRangeValidator()
+    {
+        RuleFor(r => r.WalletId).NotEmpty();
+    }
+}
+
+public class GetWalletTransactionsDateRange(IMediator mediator)
+    : Endpoint<GetWalletTransactionsDateRangeRequest, DateMinMaxDto>
+{
+    public override void Configure()
+    {
+        Get(GetWalletTransactionsDateRangeRequest.Route);
+        Roles("user");
+    }
+
+    public override async Task HandleAsync(
+        GetWalletTransactionsDateRangeRequest req,
+        CancellationToken cancel
+    )
+    {
+        var userId = User.GetUserId();
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            await SendUnauthorizedAsync(cancel);
+            return;
+        }
+
+        var result = await mediator.Send(
+            new GetWalletDateMinMaxQuery(userId, req.WalletId),
+            cancel
+        );
+
+        if (await this.SendResultIfNotOk(result, cancel))
+            return;
+
+        await SendOkAsync(result.Value, cancel);
+    }
+}

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/Wallets/ListUserArchiveWallets.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/Wallets/ListUserArchiveWallets.cs
@@ -1,15 +1,35 @@
 ﻿using FinanceTrack.Finance.UseCases.Wallets.List;
 using FinanceTrack.Finance.Web.Extensions;
+using FluentValidation;
 
 namespace FinanceTrack.Finance.Web.Wallets;
+
+public class ListUserArchiveWalletsRequest
+{
+    [QueryParam]
+    public string? AfterCursor { get; set; }
+
+    [QueryParam]
+    public int PageSize { get; set; }
+}
+
+public class ListUserArchiveWalletsValidator : Validator<ListUserArchiveWalletsRequest>
+{
+    public ListUserArchiveWalletsValidator()
+    {
+        RuleFor(r => r.PageSize).GreaterThan(0).LessThanOrEqualTo(100);
+    }
+}
 
 public class ListUserArchiveWalletsResponse
 {
     public List<WalletRecord> Wallets { get; set; } = [];
+    public string? NextCursor { get; set; }
+    public bool HasMore { get; set; }
 }
 
 public class ListUserArchiveWallets(IMediator mediator)
-    : EndpointWithoutRequest<ListUserArchiveWalletsResponse>
+    : Endpoint<ListUserArchiveWalletsRequest, ListUserArchiveWalletsResponse>
 {
     public override void Configure()
     {
@@ -17,7 +37,7 @@ public class ListUserArchiveWallets(IMediator mediator)
         Roles("user");
     }
 
-    public override async Task HandleAsync(CancellationToken ct)
+    public override async Task HandleAsync(ListUserArchiveWalletsRequest req, CancellationToken ct)
     {
         var userId = User.GetUserId();
         if (string.IsNullOrWhiteSpace(userId))
@@ -26,22 +46,33 @@ public class ListUserArchiveWallets(IMediator mediator)
             return;
         }
 
-        var wallets = await mediator.Send(new ListUserArchiveWalletsQuery(userId), ct);
+        var result = await mediator.Send(
+            new ListUserArchiveWalletsQuery(userId, req.AfterCursor, req.PageSize),
+            ct
+        );
 
-        Response = new ListUserArchiveWalletsResponse
-        {
-            Wallets = wallets
-                .Select(w => new WalletRecord(
-                    w.Id,
-                    w.Name,
-                    w.WalletType,
-                    w.Balance,
-                    w.AllowNegativeBalance,
-                    w.TargetAmount,
-                    w.TargetDate,
-                    w.IsArchived
-                ))
-                .ToList(),
-        };
+        if (await this.SendResultIfNotOk(result, ct))
+            return;
+
+        await SendOkAsync(
+            new ListUserArchiveWalletsResponse
+            {
+                Wallets = result
+                    .Value.Wallets.Select(w => new WalletRecord(
+                        w.Id,
+                        w.Name,
+                        w.WalletType,
+                        w.Balance,
+                        w.AllowNegativeBalance,
+                        w.TargetAmount,
+                        w.TargetDate,
+                        w.IsArchived
+                    ))
+                    .ToList(),
+                NextCursor = result.Value.NextCursor,
+                HasMore = result.Value.HasMore,
+            },
+            ct
+        );
     }
 }

--- a/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/Wallets/ListUserWallets.cs
+++ b/FinanceTrack.Finance/src/FinanceTrack.Finance.Web/Wallets/ListUserWallets.cs
@@ -1,16 +1,36 @@
-using FinanceTrack.Finance.UseCases.Wallets;
+﻿using FinanceTrack.Finance.UseCases.Wallets;
 using FinanceTrack.Finance.UseCases.Wallets.List;
 using FinanceTrack.Finance.Web.Extensions;
+using FluentValidation;
 
 namespace FinanceTrack.Finance.Web.Wallets;
+
+public class ListUserWalletsRequest
+{
+    [QueryParam]
+    public string? AfterCursor { get; set; }
+
+    [QueryParam]
+    public int PageSize { get; set; }
+}
+
+public class ListUserWalletsValidator : Validator<ListUserWalletsRequest>
+{
+    public ListUserWalletsValidator()
+    {
+        RuleFor(r => r.PageSize).GreaterThan(0).LessThanOrEqualTo(100);
+    }
+}
 
 public class ListUserWalletsResponse
 {
     public List<WalletRecord> Wallets { get; set; } = [];
+    public string? NextCursor { get; set; }
+    public bool HasMore { get; set; }
 }
 
 public class ListUserWallets(IMediator mediator)
-    : EndpointWithoutRequest<ListUserWalletsResponse>
+    : Endpoint<ListUserWalletsRequest, ListUserWalletsResponse>
 {
     public override void Configure()
     {
@@ -18,7 +38,7 @@ public class ListUserWallets(IMediator mediator)
         Roles("user");
     }
 
-    public override async Task HandleAsync(CancellationToken ct)
+    public override async Task HandleAsync(ListUserWalletsRequest req, CancellationToken ct)
     {
         var userId = User.GetUserId();
         if (string.IsNullOrWhiteSpace(userId))
@@ -27,16 +47,33 @@ public class ListUserWallets(IMediator mediator)
             return;
         }
 
-        var wallets = await mediator.Send(new ListUserWalletsQuery(userId), ct);
+        var result = await mediator.Send(
+            new ListUserWalletsQuery(userId, req.AfterCursor, req.PageSize),
+            ct
+        );
 
-        Response = new ListUserWalletsResponse
-        {
-            Wallets = wallets
-                .Select(w => new WalletRecord(
-                    w.Id, w.Name, w.WalletType, w.Balance,
-                    w.AllowNegativeBalance, w.TargetAmount, w.TargetDate, w.IsArchived
-                ))
-                .ToList(),
-        };
+        if (await this.SendResultIfNotOk(result, ct))
+            return;
+
+        await SendOkAsync(
+            new ListUserWalletsResponse
+            {
+                Wallets = result
+                    .Value.Wallets.Select(w => new WalletRecord(
+                        w.Id,
+                        w.Name,
+                        w.WalletType,
+                        w.Balance,
+                        w.AllowNegativeBalance,
+                        w.TargetAmount,
+                        w.TargetDate,
+                        w.IsArchived
+                    ))
+                    .ToList(),
+                NextCursor = result.Value.NextCursor,
+                HasMore = result.Value.HasMore,
+            },
+            ct
+        );
     }
 }


### PR DESCRIPTION
Реализовал KeySet пагинацию на бэкенде с бесконечной прокруткой на фронтенде.

Всё реализовано вокруг обмена курсорами между бэкендом и фронтендом, которые содержат детерминированные наборы ключей. По ним определяется место остановы предыдущей странички и возвращается следующая страничка. Курсор при этом обновляется на следующую, ныне текущую, страничку.

Курсор содержит детерминированный набор ключей, по которому однозначно можно найти последний элемент последней страницы. Клиент хранит курсор "как есть" и просто передаёт его и обновляет в последующих запросах.

Чтобы не перегружать DOM числом транзакций, на клиенте используется виртуализация. В памяти может находится 1000 транзакций, но в DOM в моменте будет не более 30.

На страничке транзакций появился внутренний скрол:
<img width="1880" height="935" alt="vivaldi_HdhDo9sKYu" src="https://github.com/user-attachments/assets/d03bb318-2a80-4b47-b50a-631445f3bf09" />


