### PR TITLE
Использование для работы с журналом команд и командами разных инстансов DbContext

### DIFF
--- a/EDMS1.CommandLog/CommandLog/Extensions/ServiceCollectionExtensions.cs
+++ b/EDMS1.CommandLog/CommandLog/Extensions/ServiceCollectionExtensions.cs
@@ -14,38 +14,34 @@ namespace EDMS1.CommandLog.Extensions;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
-    /// <summary>
-    /// <para>
-    /// Регистрация логирующихся команд: сервис журнала, контекст команды,
-    /// доступ к провайдеру и фоновый сервис повторной обработки.
-    /// </para>
-    /// <remarks>
-    /// Пример регистрации CommandLogService взят из <see href="https://github.com/dotnet/eShop/blob/main/src/Catalog.API/Extensions/Extensions.cs">eShop</see>
-    /// </remarks>
-    /// </summary>
-    /// <typeparam name="TContext">
-    /// Тип <see cref="DbContext"/> хоста, в модель которого добавлена таблица журнала (через <c>UseCommandLog</c>).
-    /// Через него сервис записывает команды журнала.
-    /// </typeparam>
-    /// <param name="services">Коллекция сервисов.</param>
-    /// <param name="assemblyMarkerType">
-    /// Любой тип из сборки, где объявлены команды (<see cref="ICommand"/>).
-    /// Используется для поиска команд и построения карты "имя:тип" для десериализации при повторной обработке.
-    /// </param>
-    /// <returns>Та же коллекция сервисов для построения цепочки вызовов.</returns>
-    public static IServiceCollection AddCommandLogService<TContext>(this IServiceCollection services)
-        where TContext : DbContext
-    {
-        services.AddSingleton<CommandTypeResolver>();
-        
-        services.AddScoped<ICommandLogService, CommandLogService<TContext>>();
-        
-        services.AddScoped<ICommandContext, CommandContext>();
-        
-        services.AddHttpContextAccessor();
-        services.AddSingleton<ServiceProviderAccessor>();
-        services.AddHostedService<CommandLogRetryBackgroundService>();
+	/// <summary>
+	/// <para>
+	/// Регистрация логирующихся команд: сервис журнала, контекст команды,
+	/// доступ к провайдеру и фоновый сервис повторной обработки.
+	/// </para>
+	/// <remarks>
+	/// Пример регистрации CommandLogService взят из <see href="https://github.com/dotnet/eShop/blob/main/src/Catalog.API/Extensions/Extensions.cs">eShop</see>
+	/// </remarks>
+	/// </summary>
+	/// <typeparam name="TContext">
+	/// Тип <see cref="DbContext"/> хоста, в модель которого добавлена таблица журнала (через <c>UseCommandLog</c>).
+	/// Через него сервис записывает команды журнала.
+	/// </typeparam>
+	/// <param name="services">Коллекция сервисов.</param>
+	/// <returns>Та же коллекция сервисов для построения цепочки вызовов.</returns>
+	public static IServiceCollection AddCommandLogService<TContext>(this IServiceCollection services)
+		where TContext : DbContext
+	{
+		services.AddSingleton<CommandTypeResolver>();
 
-        return services;
-    }
+		services.AddScoped<ICommandLogService, CommandLogService<TContext>>();
+
+		services.AddScoped<ICommandContext, CommandContext>();
+
+		services.AddHttpContextAccessor();
+		services.AddSingleton<ServiceProviderAccessor>();
+		services.AddHostedService<CommandLogRetryBackgroundService>();
+
+		return services;
+	}
 }

--- a/EDMS1.CommandLog/CommandLog/README.md
+++ b/EDMS1.CommandLog/CommandLog/README.md
@@ -33,7 +33,7 @@ public class AppDbContext : DbContext
 Там, где регистрируете сервисы, вызовите `AddCommandLogService<TContext>`:
 
 - **Обобщённый параметр `<TContext>`** — `DbContext`, где используется `UseCommandLog();`. Сервис журнала будет
-  писать команды именно в этот контекст.
+  писать команды в отдельный контекст данного типа.
 
 ```csharp
 using EDMS1.CommandLog.Extensions;

--- a/EDMS1.CommandLog/CommandLog/Services/CommandLogService.cs
+++ b/EDMS1.CommandLog/CommandLog/Services/CommandLogService.cs
@@ -5,6 +5,7 @@ using EDMS1.CommandLog.Models;
 using EDMS1.CommandLog.Resolvers;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -18,117 +19,152 @@ namespace EDMS1.CommandLog.Services;
 /// Пример реализации взят из <see href="https://github.com/dotnet/eShop/tree/main/src/IntegrationEventLogEF">eShop</see>
 /// </remarks>
 /// </summary>
-internal sealed class CommandLogService<TContext> : ICommandLogService
-    where TContext : DbContext
+internal sealed class CommandLogService<TContext> : ICommandLogService, IDisposable, IAsyncDisposable
+	where TContext : DbContext
 {
-    private readonly CommandTypeResolver _typeResolver;
-    private readonly IMediator _mediator;
-    private readonly TContext _dbContext;
-    private readonly ILogger<CommandLogService<TContext>> _logger;
+	private readonly CommandTypeResolver _typeResolver;
+	private readonly IMediator _mediator;
+	private readonly TContext _appDbContext;
+	private readonly ILogger<CommandLogService<TContext>> _logger;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CommandLogService{TContext}"/> class.
-    /// </summary>
-    public CommandLogService(TContext dbContext, CommandTypeResolver typeResolver, ILogger<CommandLogService<TContext>> logger, IMediator mediator)
-    {
-        _typeResolver = typeResolver;
-        _logger = logger;
-        _mediator = mediator;
-        _dbContext = dbContext;
-    }
+	// Нужны для получения DbContext, используемого в журналировании
+	private readonly IServiceScopeFactory _scopeFactory;
+	private IServiceScope? _journalScope;
 
-    /// <inheritdoc/>
-    public async Task LogCommandAsync(ICommand command, CommandResult result, Guid transactionId)
-    {
-        var commandLogEntry = CommandLogEntry.Create(
-            command,
-            transactionId,
-            result.Status,
-            null,
-            result.Comment);
+	private TContext CommandLogDbContext
+	{
+		get
+		{
+			_journalScope ??= _scopeFactory.CreateScope();
+			return _journalScope.ServiceProvider.GetRequiredService<TContext>();
+		}
+	}
 
-        _dbContext.Set<CommandLogEntry>().Add(commandLogEntry);
+	/// <summary>
+	/// Initializes a new instance of the <see cref="CommandLogService{TContext}"/> class.
+	/// </summary>
+	public CommandLogService(IServiceScopeFactory scopeFactory, TContext appDbContext,
+		CommandTypeResolver typeResolver,
+		ILogger<CommandLogService<TContext>> logger, IMediator mediator)
+	{
+		_typeResolver = typeResolver;
+		_logger = logger;
+		_mediator = mediator;
+		_scopeFactory = scopeFactory;
 
-        await _dbContext.SaveChangesAsync();
-    }
+		// Этот же dbContext используют обработчики команд.
+		// Нужен для подготовки контекста между ретраями команд (см. блок finally в RetryCommandsAsync).
+		_appDbContext = appDbContext;
+	}
 
-    /// <inheritdoc/>
-    public async Task LogFailedCommandAsync(ICommand command, Guid transactionId, string message)
-    {
-        var commandLogEntry = CommandLogEntry.Create(
-            command,
-            transactionId,
-            CommandStatus.Failed,
-            message,
-            null);
+	/// <inheritdoc/>
+	public async Task LogCommandAsync(ICommand command, CommandResult result, Guid transactionId)
+	{
+		var commandLogEntry = CommandLogEntry.Create(
+			command,
+			transactionId,
+			result.Status,
+			null,
+			result.Comment);
 
-        _dbContext.Set<CommandLogEntry>().Add(commandLogEntry);
+		CommandLogDbContext.Set<CommandLogEntry>().Add(commandLogEntry);
 
-        await _dbContext.SaveChangesAsync();
-    }
+		await CommandLogDbContext.SaveChangesAsync();
+	}
 
-    /// <inheritdoc/>
-    public Task LogRetryCommandAsync(Guid id)
-    {
-        return UpdateLogStatusAsync(id, CommandStatus.Retry, CancellationToken.None);
-    }
+	/// <inheritdoc/>
+	public async Task LogFailedCommandAsync(ICommand command, Guid transactionId, string message)
+	{
+		var commandLogEntry = CommandLogEntry.Create(
+			command,
+			transactionId,
+			CommandStatus.Failed,
+			message,
+			null);
 
-    /// <inheritdoc/>
-    public async Task RetryCommandNowAsync(Guid id, CancellationToken cancel)
-    {
-        var commandLog = await UpdateLogStatusAsync(id, CommandStatus.Retry, cancel);
+		CommandLogDbContext.Set<CommandLogEntry>().Add(commandLogEntry);
 
-        await RetryCommandAsync(commandLog, cancel);
-    }
+		await CommandLogDbContext.SaveChangesAsync();
+	}
 
-    /// <inheritdoc/>
-    public async Task RetryCommandsAsync(CancellationToken cancel)
-    {
-        var commandLogs = await _dbContext.Set<CommandLogEntry>().AsNoTracking()
-            .Where(x => x.Status == CommandStatus.Retry.ToString())
-            .OrderBy(x => x.CreationTime)
-            .Take(1000)
-            .ToListAsync(cancel);
+	/// <inheritdoc/>
+	public Task LogRetryCommandAsync(Guid id)
+	{
+		return UpdateLogStatusAsync(id, CommandStatus.Retry, CancellationToken.None);
+	}
 
-        foreach (var commandLog in commandLogs)
-        {
-            try
-            {
-                await RetryCommandAsync(commandLog, cancel);
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogInformation("Retrying of commands was cancelled.");
+	/// <inheritdoc/>
+	public async Task RetryCommandNowAsync(Guid id, CancellationToken cancel)
+	{
+		var commandLog = await UpdateLogStatusAsync(id, CommandStatus.Retry, cancel);
 
-                throw;
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Retrying of commands was failed.");
-            }
-        }
-    }
+		await RetryCommandAsync(commandLog, cancel);
+	}
 
-    private async Task RetryCommandAsync(CommandLogEntry cmdLogEntry, CancellationToken cancel)
-    {
-        var command = JsonConvert.DeserializeObject(cmdLogEntry.Command, _typeResolver.Resolve(cmdLogEntry.CommandName))
-            ?? throw new SerializationException(
-                $"Cannot deserialize retry command {cmdLogEntry.Command} to type {cmdLogEntry.CommandName}.");
-        
-        await UpdateLogStatusAsync(cmdLogEntry.CommandLogId, CommandStatus.RetryProcessed, cancel);
+	/// <inheritdoc/>
+	public async Task RetryCommandsAsync(CancellationToken cancel)
+	{
+		var commandLogs = await CommandLogDbContext.Set<CommandLogEntry>().AsNoTracking()
+			.Where(x => x.Status == CommandStatus.Retry.ToString())
+			.OrderBy(x => x.CreationTime)
+			.Take(1000)
+			.ToListAsync(cancel);
 
-        await _mediator.Send(command, cancel);
-    }
+		foreach (var commandLog in commandLogs)
+			try
+			{
+				await RetryCommandAsync(commandLog, cancel);
+			}
+			catch (OperationCanceledException)
+			{
+				_logger.LogInformation("Retrying of commands was cancelled.");
 
-    private async Task<CommandLogEntry> UpdateLogStatusAsync(Guid id, CommandStatus status, CancellationToken cancel)
-    {
-        var commandLog = await _dbContext.Set<CommandLogEntry>().FindAsync([id], cancel)
-            ?? throw new EntityNotFoundException(nameof(CommandLogEntry), nameof(CommandLogEntry.CommandLogId), id);
+				throw;
+			}
+			catch (Exception e)
+			{
+				_logger.LogError(e, "Retrying of commands was failed.");
+			}
+			finally
+			{
+				_appDbContext.ChangeTracker.Clear();
+			}
+	}
 
-        commandLog.Status = status.ToString();
+	private async Task RetryCommandAsync(CommandLogEntry cmdLogEntry, CancellationToken cancel)
+	{
+		var command = JsonConvert.DeserializeObject(cmdLogEntry.Command, _typeResolver.Resolve(cmdLogEntry.CommandName))
+		              ?? throw new SerializationException(
+			              $"Cannot deserialize retry command {cmdLogEntry.Command} to type {cmdLogEntry.CommandName}.");
 
-        await _dbContext.SaveChangesAsync(cancel);
+		await UpdateLogStatusAsync(cmdLogEntry.CommandLogId, CommandStatus.RetryProcessed, cancel);
 
-        return commandLog;
-    }
+		await _mediator.Send(command, cancel);
+	}
+
+	private async Task<CommandLogEntry> UpdateLogStatusAsync(Guid id, CommandStatus status, CancellationToken cancel)
+	{
+		var commandLog = await CommandLogDbContext.Set<CommandLogEntry>().FindAsync([id], cancel)
+		                 ?? throw new EntityNotFoundException(nameof(CommandLogEntry),
+			                 nameof(CommandLogEntry.CommandLogId), id);
+
+		commandLog.Status = status.ToString();
+
+		await CommandLogDbContext.SaveChangesAsync(cancel);
+
+		return commandLog;
+	}
+
+	public void Dispose()
+	{
+		_journalScope?.Dispose();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		if (_journalScope is IAsyncDisposable journalScopeAsyncDisposable)
+			await journalScopeAsyncDisposable.DisposeAsync();
+		else
+			_journalScope?.Dispose();
+	}
 }


### PR DESCRIPTION
Сделал по варианту 1. Все тесты проходят (даже тот, который ранее не проходил, хотя должен был).

Пока разобрался, как сделать, пришлось несколько вариантов решения перебрать. Сначала попробовал через IDbContextFactory, но там возникли нюансы, связанные с Lifetime и появлением необходимости в дублировании и модификации options из AddDbContext в AddDbContextFactory при передаче. 

Сейчас оно работает так. Внутри сервиса журналирования создаётся отдельный Scope, из него и получаем DbContext для журналирования. Время жизни этого Scope привязано к времени жизни CommandLogService.

Попутно сделал диаграмму для лучшего понимания. Текущее поведение - это которое было "до".
<img width="2161" height="5264" alt="CommandLog drawio" src="https://github.com/user-attachments/assets/470d16e2-3e48-49b6-9ef2-2d9968cbe8d9" />